### PR TITLE
docs: update documentation for hybrid build strategy implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,25 @@ docker buildx build \
 
 This repository uses GitHub Actions for automated building and publishing:
 
-- **Master Branch**: Builds and publishes all Alpine versions as production images
+- **Master Branch**: Builds and publishes all Alpine versions as production images using hybrid build strategy
 - **Feature Branches**: Builds development images tagged with commit SHA
 - **Manual Triggers**: Workflows can be triggered manually via GitHub Actions UI
+
+### Docker Hub Image Ordering
+
+Images appear on Docker Hub in build completion order. The master branch uses a **hybrid build strategy** to ensure proper ordering:
+
+- **Legacy versions** (3.14.3-3.21.4): Built in parallel for speed
+- **Current version** (3.22.1): Built sequentially after legacy versions  
+- **Latest tag**: Built last to appear at the end of the image list
+
+**Result**: The most relevant images (current version and latest) appear at the end of Docker Hub listings in predictable order.
+
+### Build Performance
+- **Legacy Versions**: ~10-15 minutes (parallel)
+- **Current Version**: ~3-5 minutes (sequential) 
+- **Latest Tag**: ~3-5 minutes (sequential)
+- **Total Time**: ~15-25 minutes with proper ordering
 
 ### Build Matrix
 Each workflow run builds:


### PR DESCRIPTION
## Summary

Updates documentation to reflect the hybrid build strategy implementation that was merged in PR #33.

## Changes Made

### CLAUDE.md Updates
- **Hybrid Build Strategy**: Detailed explanation of 3-stage approach (legacy parallel, current sequential, latest sequential)
- **Version Management**: Complete procedures for adding new Alpine versions
- **Build Performance**: Timing breakdown and benefits (~15-25min vs 60-90min)
- **Workflow Architecture**: Explanation of legacy vs current version concepts

### README.md Updates  
- **Docker Hub Image Ordering**: How hybrid strategy ensures proper image ordering
- **Build Performance**: Performance metrics for each stage
- **Strategy Benefits**: Why current version and latest tag appear last

## Documentation Highlights

### Build Process (Master Branch)
1. **Legacy Versions** (3.14.3-3.21.4): Built in parallel (~10-15 minutes)
2. **Current Version** (3.22.1): Built sequentially after legacy (~3-5 minutes)  
3. **Latest Tag**: Built last for proper Docker Hub ordering (~3-5 minutes)

### Expected Docker Hub Result
- Most relevant images (current version and latest) appear at end of listings
- Predictable ordering every time vs random parallel completion order
- Fast build times maintained while achieving proper presentation

## Related

- Completes documentation for issue #32  
- Follows up on implementation in PR #33